### PR TITLE
 Fix existing test failures

### DIFF
--- a/roaring/roaring_pooling_test.go
+++ b/roaring/roaring_pooling_test.go
@@ -1,0 +1,43 @@
+package roaring
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// TestBitmap_Reset verifies that the Reset method always restores a Bitmap
+// to a state indistinguishable from a new one.
+func TestBitmap_Reset(t *testing.T) {
+	bm := NewBitmapWithDefaultPooling(10)
+
+	i := uint64(0)
+	for {
+		if i >= 10000 {
+			break
+		}
+
+		bm.Add(10000 * i)
+		i++
+	}
+	untouched := NewBitmapWithDefaultPooling(10)
+	bm.Reset()
+
+	if !cmp.Equal(untouched, bm, cmp.Comparer(func(x, y Bitmap) bool {
+		if x.Containers.Size() != y.Containers.Size() {
+			return false
+		}
+		if x.Containers.Count() != y.Containers.Count() {
+			return false
+		}
+		if x.opN != y.opN {
+			return false
+		}
+		if x.OpWriter != y.OpWriter {
+			return false
+		}
+		return true
+	})) {
+		t.Fatalf("Reset bitmap: %+v is not identical to new bitmap: %+v", bm, untouched)
+	}
+}

--- a/roaring/roaring_test.go
+++ b/roaring/roaring_test.go
@@ -1406,28 +1406,6 @@ func TestBitmap_Intersect(t *testing.T) {
 	}
 }
 
-// TestBitmap_Reset verifies that the Reset method always restores a Bitmap
-// to a state indistinguishable from a new one.
-func TestBitmap_Reset(t *testing.T) {
-	bm := roaring.NewBitmapWithDefaultPooling(10)
-
-	i := uint64(0)
-	for {
-		if i >= 10000 {
-			break
-		}
-
-		bm.Add(10000 * i)
-		i++
-	}
-
-	untouched := roaring.NewBitmapWithDefaultPooling(10)
-	bm.Reset()
-	if !reflect.DeepEqual(untouched, bm) {
-		t.Fatalf("Reset bitmap: %+v is not identical to new bitmap: %+v", bm, untouched)
-	}
-}
-
 func BenchmarkGetBenchData(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		sampleData = benchmarkSampleData{}

--- a/translate.go
+++ b/translate.go
@@ -252,6 +252,8 @@ func (s *TranslateFile) size() int64 {
 
 // isReadOnly returns true if this store is being replicated from a primary store.
 func (s *TranslateFile) isReadOnly() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.PrimaryTranslateStore != nil
 }
 


### PR DESCRIPTION
## Overview

Fix existing test failures, so test suite passes. Results after merging #1 and #2 into this branch:
```
╰─$ make test-race                                                                                                                                                           130 ↵
go test -timeout 20m -race ./... -tags=' '
ok  	github.com/m3dbx/pilosa	90.464s
?   	github.com/m3dbx/pilosa/boltdb	[no test files]
ok  	github.com/m3dbx/pilosa/cmd	1.728s
?   	github.com/m3dbx/pilosa/cmd/pilosa	[no test files]
ok  	github.com/m3dbx/pilosa/ctl	6.521s
?   	github.com/m3dbx/pilosa/encoding/proto	[no test files]
?   	github.com/m3dbx/pilosa/enterprise	[no test files]
?   	github.com/m3dbx/pilosa/enterprise/b	[no test files]
?   	github.com/m3dbx/pilosa/gcnotify	[no test files]
ok  	github.com/m3dbx/pilosa/gopsutil	1.443s
?   	github.com/m3dbx/pilosa/gossip	[no test files]
ok  	github.com/m3dbx/pilosa/http	6.796s
ok  	github.com/m3dbx/pilosa/inmem	(cached)
?   	github.com/m3dbx/pilosa/internal	[no test files]
ok  	github.com/m3dbx/pilosa/internal/clustertests	(cached)
ok  	github.com/m3dbx/pilosa/internal/test	(cached)
?   	github.com/m3dbx/pilosa/logger	[no test files]
?   	github.com/m3dbx/pilosa/lru	[no test files]
?   	github.com/m3dbx/pilosa/mock	[no test files]
ok  	github.com/m3dbx/pilosa/pql	1.441s
ok  	github.com/m3dbx/pilosa/roaring	708.586s
ok  	github.com/m3dbx/pilosa/server	174.753s
ok  	github.com/m3dbx/pilosa/stats	2.596s
ok  	github.com/m3dbx/pilosa/statsd	1.357s
ok  	github.com/m3dbx/pilosa/test	1.626s
?   	github.com/m3dbx/pilosa/toml	[no test files]
?   	github.com/m3dbx/pilosa/tracing	[no test files]
?   	github.com/m3dbx/pilosa/tracing/opentracing	[no test files]
make test-race  1048.52s user 81.05s system 157% cpu 11:55.40 total
```

Updates m3db/m3#2540